### PR TITLE
Exception handling for find_and_modify()

### DIFF
--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -50,8 +50,8 @@ module Delayed
             # Return result as a Mongoid document.
             # When Mongoid starts supporting findAndModify, this extra step should no longer be necessary.
             self.find(:first, :conditions => {:_id => result["_id"]})
-          rescue
-            nil
+          rescue Mongo::OperationFailure => bang
+            bang.message =~ /'findandmodify' failed:.*No matching object found.*/ ? nil : raise
           end
         end
 


### PR DESCRIPTION
Added stricter exception handling during this method call so as to _not_ ignore real errors like network disconnects.

...
rescue Mongo::OperationFailure => bang
  bang.message =~ /'findandmodify' failed:._No matching object found._/ ? nil : raise
end

I'm not so sure though if we really need to suffer a performance hit performing a regex eval on the message string every single time or if we can just assume that every Mongo::OperationFailure (database error) is close enough that we can return nil.

Btw, a network disconnect is raised as a Mongo::ConnectionFailure (different from the above).

If I seem to be rambling, blame it on the lack of caffeine. =)

Thanks!
