### PR TITLE
Mongo 2.0 can return nil for findAndModify - causing dj to terminate

### DIFF
--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -55,6 +55,9 @@ module Delayed
               :update => {"$set" => {:locked_at => right_now, :locked_by => worker.name}}
             )
 
+            # As of Mongo 2.0, findAndModify will return a nil result for no match.
+            return nil if result.nil?
+            
             # Return result as a Mongoid document.
             # When Mongoid starts supporting findAndModify, this extra step should no longer be necessary.
             self.find(:first, :conditions => {:_id => result["_id"]})


### PR DESCRIPTION
As per https://jira.mongodb.org/browse/SERVER-2757 - for Mongo 2.0, findAndModify will now return nil for "no matches", where it previously threw an exception.

Requires an extra check in the result of the find_and_modify. Without it, delayed_job exits with:
"
You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.[]
"
