### PR TITLE
Fix for Mongodb 2.0

### DIFF
--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -62,7 +62,7 @@ module Delayed
 
             # Return result as a Mongoid document.
             # When Mongoid starts supporting findAndModify, this extra step should no longer be necessary.
-            self.find(:first, :conditions => {:_id => result["_id"]})
+            self.find(:first, :conditions => {:_id => result["_id"]}) if result
           rescue Mongo::OperationFailure
             nil # no jobs available
           end


### PR DESCRIPTION
Hey all !

The findAndModify command in Mongodb 2.0 no longer throws an exception when no document is found, instead it returns a nil result.

This minor fix handle both cases.

Cheers,

Mathieu
