### PR TITLE
Update readme to mention MongoDB 1.3 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # delayed_job Mongoid backend
 
+## Requirements
+
+Make sure you are using MongoDB version 1.3 or newer. `delayed_job_mongoid` uses the `findandmodify` command which is only available in recent versions.
+
+
 ## Installation
 
-Add the gems to your Gemfile:
+Add the gem to your Gemfile:
 
-    gem 'delayed_job'
     gem 'delayed_job_mongoid'
 
 After running `bundle install`, create the indexes (and don't forget to do this on your production database):


### PR DESCRIPTION
I also removed the line to add `delayed_job` to the Gemfile. It's already a runtime dependency, so you're not required to specify it.
