### PR TITLE
README includes steps to generate script/delayed_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,9 @@ on your production database):
 
     script/rails runner 'Delayed::Backend::Mongoid::Job.create_indexes'
 
+To generate script/delayed_job:
+
+    rails generate delayed_job
+
 That's it. Use [delayed_job](http://github.com/collectiveidea/delayed_job) as
 normal.


### PR DESCRIPTION
The instructions on the delayed_job repo include the active_record 'rails g' step which adds script/delayed_job. As this script is referenced from other places (e.g. the cap wiki page) thought it would be useful to add in how to generate it here too.
