### PR TITLE
Instead of performing a redundant query, just wrap the result

### DIFF
--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -67,8 +67,10 @@ module Delayed
             )
 
             # Return result as a Mongoid document.
-            # When Mongoid starts supporting findAndModify, this extra step should no longer be necessary.
-            self.find(:first, :conditions => {:_id => result["_id"]}) unless result.nil?
+            new.tap do |job|
+              job.new_record = false
+              job.assign_attributes(result)
+            end unless result.nil?
           rescue Mongo::OperationFailure
             nil # no jobs available
           end


### PR DESCRIPTION
Something that I promised some time ago. This is a patch we've been using for a long time in order to reduce the number of queries. I believe that the master branch doesn't need it because of the findAndModify support in Mongoid-3.
