### PR TITLE
Fixes issue #23 identity map not cleared

### DIFF
--- a/lib/delayed/plugins.rb
+++ b/lib/delayed/plugins.rb
@@ -1,0 +1,17 @@
+#
+# clear Mongoid::IdentityMap before each job
+#
+
+module Delayed
+  module Plugins
+    class ClearIdentityMap < Plugin
+      callbacks do |lifecycle|
+        lifecycle.before(:invoke_job) do |worker, &block|
+          Mongoid::IdentityMap.clear
+        end
+      end
+    end
+  end
+end
+
+Delayed::Worker.plugins << Delayed::Plugins::ClearIdentityMap

--- a/lib/delayed_job_mongoid.rb
+++ b/lib/delayed_job_mongoid.rb
@@ -2,5 +2,6 @@
 require 'delayed/backend/mongoid'
 require 'delayed/serialization/mongoid'
 require 'delayed_job'
+require 'delayed/plugins'
 
 Delayed::Worker.backend = :mongoid


### PR DESCRIPTION
Resets the identity map at the beginning of each job.

Without this, if mongoid's identity map is enabled, DJ acts truly bizarre, using stale versions of objects seemingly at random.  I lose a solid week to this.

Patch taken from @gurgeous.
