### PR TITLE
Compatibility with Mongoid 4.0 and DJ 4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
   - 2.0.0
 services:
   - mongodb
+env:
+  - MONGOID_VERSION=3
+  - MONGOID_VERSION=4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Next Release
+============
+* [#38](https://github.com/collectiveidea/delayed_job_mongoid/pull/38): Fix clearing identity map before each job - [@srleo](https://github.com/srleo)
+* [#43](https://github.com/collectiveidea/delayed_job_mongoid/pull/43): Compatibility with Mongoid 4.x and Delayed Job 4.x - [@dblock](https://github.com/dblock)
+
+2.0.0
+=====
+* Added code coverage with SimpleCov - [@sferik](https://github.com/sferik)
+* Added Mongoid 3.0 support - [@sferik](https://github.com/sferik), [@asavartsov](https://github.com/asavartsov)
+
 1.0.2 - 2010-01-12
 ==================
 * Fix a potential memory leak inside mongo when reserving jobs on mongo 1.6+

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,12 @@ group :test do
 end
 
 gemspec
+
+case version = ENV['MONGOID_VERSION'] || '~> 3.1'
+when /4/
+  gem 'mongoid', github: 'mongoid/mongoid'
+when /3/
+  gem 'mongoid', '~> 3.1'
+else
+  gem 'mongoid', version
+end

--- a/delayed_job_mongoid.gemspec
+++ b/delayed_job_mongoid.gemspec
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.add_dependency    'delayed_job', '~> 3.0'
-  spec.add_dependency    'mongoid', '~> 3.0'
+  spec.add_dependency    'delayed_job', ['>= 3.0', '< 5']
+  spec.add_dependency    'mongoid', ['>= 3.0', '< 5']
   spec.authors         = ["Chris Gaffney", "Brandon Keepers", "Erik Michaels-Ober"]
   spec.email           = ['chris@collectiveidea.com', 'brandon@opensoul.com', 'sferik@gmail.com']
   spec.files           = %w(CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md Rakefile delayed_job_mongoid.gemspec)

--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -63,6 +63,9 @@ module Delayed
           super
         end
       end
+      def self.mongoid3?
+        ::Mongoid.const_defined? :Observer # deprecated in Mongoid 4.x
+      end
     end
   end
 end

--- a/lib/delayed/plugins.rb
+++ b/lib/delayed/plugins.rb
@@ -2,16 +2,18 @@
 # clear Mongoid::IdentityMap before each job
 #
 
-module Delayed
-  module Plugins
-    class ClearIdentityMap < Plugin
-      callbacks do |lifecycle|
-        lifecycle.before(:invoke_job) do |worker, &block|
-          Mongoid::IdentityMap.clear
+if Delayed::Backend::Mongoid.mongoid3?
+  module Delayed
+    module Plugins
+      class ClearIdentityMap < Plugin
+        callbacks do |lifecycle|
+          lifecycle.before(:invoke_job) do |worker, &block|
+            Mongoid::IdentityMap.clear
+          end
         end
       end
     end
   end
-end
 
-Delayed::Worker.plugins << Delayed::Plugins::ClearIdentityMap
+  Delayed::Worker.plugins << Delayed::Plugins::ClearIdentityMap
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -17,6 +17,8 @@ end
 
 class Story
   include ::Mongoid::Document
+  field :text
+
   def tell; text; end
   def whatever(n, _); tell*n; end
   def self.count; end

--- a/spec/plugins_spec.rb
+++ b/spec/plugins_spec.rb
@@ -1,0 +1,23 @@
+require 'helper'
+
+if Delayed::Backend::Mongoid.mongoid3?
+  describe Delayed::Backend::Mongoid::Job do
+    let(:worker) { Delayed::Worker.new }
+    before do
+      Delayed::Worker.max_priority = nil
+      Delayed::Worker.min_priority = nil
+      Delayed::Worker.default_priority = 99
+      Delayed::Worker.delay_jobs = true
+      SimpleJob.runs = 0
+      described_class.delete_all
+    end
+    after do
+      Delayed::Worker.reset
+    end
+    it "clears mongoid identity map" do
+      Mongoid::IdentityMap.should_receive(:clear).once
+      job = described_class.enqueue SimpleJob.new, priority: 5
+      worker.work_off
+    end
+  end
+end


### PR DESCRIPTION
Since Mongoid 4.x hasn't been released, you can test this by adding the following to Gemfile above `gemspec`:

```
gem "delayed_job", "~> 4.0"
gem "mongoid", github: "mongoid/mongoid"
```

We can lock both `< 5` if you prefer, lmk.

Bonus: Updated CHANGELOG with release notes for 2.0 and next release. 
