### PR TITLE
Fixed compatibility with Mongoid 4.0.0.alpha2

### DIFF
--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -62,6 +62,12 @@ module Delayed
           reset
           super
         end
+
+        # Hook method that is called after a new worker is forked
+        def self.after_fork
+          # to avoid `failed with error "unauthorized"` errors in Mongoid 4.0.alpha2
+          ::Mongoid.default_session.disconnect
+        end
       end
       def self.mongoid3?
         ::Mongoid.const_defined? :Observer # deprecated in Mongoid 4.x


### PR DESCRIPTION
fix for errors like that:

```
I, [2014-02-01T03:52:53.378349 #23936]  INFO -- : 2014-02-01T03:52:53-0500: [Worker(delayed_job host:some_server_name_here pid:23936)] Error while reserving job: The operation: #<Moped::Protocol::Command
  @length=436
  @request_id=8
  @response_to=0
  @op_code=2004
  @flags=[]
  @full_collection_name="collection_name_here.$cmd"
  @skip=0
  @limit=-1
  @selector={:findAndModify=>"delayed_backend_mongoid_jobs", :query=>{"run_at"=>{"$lte"=>2014-02-01 08:52:53 UTC}, "failed_at"=>nil, "$or"=>[{"locked_by"=>"delayed_job host:some_server_name_here pid:23936"}, {"locked_at"=>nil}, {"locked_at"=>{"$lt"=>2014-02-01 04:52:53 UTC}}]}, :new=>true, :sort=>{"locked_by"=>-1, "priority"=>1, "run_at"=>1}, :update=>{"$set"=>{:locked_at=>2014-02-01 08:52:53 UTC, :locked_by=>"delayed_job host:some_server_name_here pid:23936"}}}
  @fields=nil>
failed with error "unauthorized"
```
