### PR TITLE
Adds support for Mongoid 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ when /4/
   gem 'mongoid', '~> 4.0'
 when /3/
   gem 'mongoid', '~> 3.1'
+when /5/
+  gem 'mongoid', github: "mongodb/mongoid"
 else
   gem 'mongoid', version
 end


### PR DESCRIPTION
Specs passing with Mongoid 5, though currently pulls source directly from `mongodb/mongoid`.

```
MONGOID_VERSION=5 bundle install
MONGOID_VERSION=5 bundle exec rspec spec

Finished in 1.75 seconds (files took 0.54175 seconds to load)
78 examples, 0 failures
```