### PR TITLE
Use mongoid-compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,12 @@ group :test do
   gem 'yardstick'
 end
 
-case version = ENV['MONGOID_VERSION'] || '>= 5.0'
-when /5/
+case version = ENV['MONGOID_VERSION'] || '5.0'
+when /^5/
   gem 'mongoid', '~> 5.0'
-when /4/
+when /^4/
   gem 'mongoid', '~> 4.0'
-when /3/
+when /^3/
   gem 'mongoid', '~> 3.1'
 else
   gem 'mongoid', version

--- a/delayed_job_mongoid.gemspec
+++ b/delayed_job_mongoid.gemspec
@@ -3,6 +3,7 @@
 Gem::Specification.new do |spec|
   spec.add_dependency 'delayed_job', ['>= 3.0', '< 5']
   spec.add_dependency 'mongoid', ['>= 3.0', '< 6']
+  spec.add_dependency 'mongoid-compatibility'
   spec.authors         = ['Chris Gaffney', 'Brandon Keepers', 'Erik Michaels-Ober']
   spec.email           = ['chris@collectiveidea.com', 'brandon@opensoul.com', 'sferik@gmail.com']
   spec.files           = %w[CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md delayed_job_mongoid.gemspec] + Dir['lib/**/*.rb']

--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'delayed_job'
 require 'mongoid'
+require 'mongoid/compatibility'
 
 module Delayed
   module Backend
@@ -36,7 +37,7 @@ module Delayed
 
           criteria = reservation_criteria worker, right_now, max_run_time
 
-          if Gem::Version.create(::Mongoid::VERSION) >= Gem::Version.create('5.0.0')
+          if ::Mongoid::Compatibility::Version.mongoid5?
             criteria.find_one_and_update(
               {'$set' => {:locked_at => right_now, :locked_by => worker.name}},
               :return_document => :after
@@ -84,14 +85,11 @@ module Delayed
 
         # Hook method that is called after a new worker is forked
         def self.after_fork
-          if Gem::Version.create(::Mongoid::VERSION) < Gem::Version.create('5.0.0')
+          if ::Mongoid::Compatibility::Version.mongoid4?
             # to avoid `failed with error "unauthorized"` errors in Mongoid 4.0.alpha2
             ::Mongoid.default_session.disconnect
           end
         end
-      end
-      def self.mongoid3?
-        ::Mongoid.const_defined? :Observer # deprecated in Mongoid 4.x
       end
     end
   end

--- a/lib/delayed/plugins.rb
+++ b/lib/delayed/plugins.rb
@@ -2,7 +2,7 @@
 # clear Mongoid::IdentityMap before each job
 #
 
-if Delayed::Backend::Mongoid.mongoid3?
+if ::Mongoid::Compatibility::Version.mongoid3?
   module Delayed
     module Plugins
       class ClearIdentityMap < Plugin

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -11,10 +11,15 @@ end
 require 'rspec'
 require 'delayed_job_mongoid'
 require 'delayed/backend/shared_spec'
+require 'mongoid/compatibility'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+  config.before :all do
+    Mongoid.logger.level = Logger::INFO
+    Mongo::Logger.logger.level = Logger::INFO if Mongoid::Compatibility::Version.mongoid5?
   end
 end
 

--- a/spec/plugins_spec.rb
+++ b/spec/plugins_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-if Delayed::Backend::Mongoid.mongoid3?
+if ::Mongoid::Compatibility::Version.mongoid3?
   describe Delayed::Backend::Mongoid::Job do
     let(:worker) { Delayed::Worker.new }
     before do


### PR DESCRIPTION
* Remove two ways of checking for Mongoid version (one which defines `mongoid3?` and another that checks version via `Gem::`) in favor of [mongoid-compatibility](https://github.com/dblock/mongoid-compatibility).
* Correct version checking in Gemfile, only beginning of string.
* Don't assume that version 6 of mongoid will work.
* Narrow hack for Mongoid 4 beta. Maybe this should just be removed?