### PR TITLE
Demonstrate issue with Ruby 2.3 and Mongoid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
   - jruby-19mode
   - jruby-9000
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
   - jruby-19mode
   - jruby-9000
   - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ else
   gem 'mongoid', version
 end
 
+gem 'delayed_job', git: 'git@github.com:maxjacobson/delayed_job.git', branch: 'fix-yaml-deserialization-error'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,5 @@ else
   gem 'mongoid', version
 end
 
-gem 'delayed_job', git: 'git@github.com:maxjacobson/delayed_job.git', branch: 'fix-yaml-deserialization-error'
+gem 'delayed_job', :git => 'https://github.com/maxjacobson/delayed_job.git', :branch => 'fix-yaml-deserialization-error'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,4 @@ else
   gem 'mongoid', version
 end
 
-gem 'delayed_job', :git => 'https://github.com/maxjacobson/delayed_job.git', :branch => 'fix-yaml-deserialization-error'
 gemspec

--- a/spec/delayed_job_mongoid_spec.rb
+++ b/spec/delayed_job_mongoid_spec.rb
@@ -1,5 +1,25 @@
 require 'helper'
 
+class StoryWrapperJob < SimpleJob
+  def initialize
+    @story = Story.create!(:text => 'My great story')
+    @story_again = @story
+  end
+
+  def perform
+    @story.tell
+    super
+  end
+end
+
 describe Delayed::Backend::Mongoid::Job do
   it_behaves_like 'a delayed_job backend'
+
+
+  context 'when job contains two instance variables that reference the same Mongoid document' do
+    it 'can serialize and deserialize the job' do
+      job = Delayed::Job.create :payload_object => StoryWrapperJob.new
+      expect(job.reload.payload_object).to be_a StoryWrapperJob
+    end
+  end
 end


### PR DESCRIPTION
I've added a test to the main delayed job repo (https://github.com/collectiveidea/delayed_job/pull/867) , so this PR is making sure the mongoid specs pass with that added test. I think they will, except for Ruby 2.3, which is using a newer version of Psych.
