### PR TITLE
Improve how forking is handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 3.0.0 (Next)
 
 * [#81](https://github.com/collectiveidea/delayed_job_mongoid/pull/81): Drop support for Mongoid 3.0 and 4.0 - [johnnyshields](https://github.com/johnnyshields).
-* [#81](https://github.com/collectiveidea/delayed_job_mongoid/pull/81): Perform disconnect on after_fork on all Mongoid versions - [johnnyshields](https://github.com/johnnyshields).
+* [#82](https://github.com/collectiveidea/delayed_job_mongoid/pull/82): Correctly handle before_fork and after_fork hooks - [johnnyshields](https://github.com/johnnyshields).
 * Your contribution here.
 
 ### 2.3.1 (2019/02/26)

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :test do
   gem 'rspec', '>= 3'
   gem 'rubocop', '0.65.0'
   gem 'simplecov', '>= 0.9'
-  gem 'yardstick'
 end
 
 case version = ENV['MONGOID_VERSION'] || '7.0'

--- a/Rakefile
+++ b/Rakefile
@@ -13,15 +13,4 @@ task test: :spec
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-require 'yardstick/rake/measurement'
-Yardstick::Rake::Measurement.new do |measurement|
-  measurement.output = 'measurement/report.txt'
-end
-
-require 'yardstick/rake/verify'
-Yardstick::Rake::Verify.new do |verify|
-  verify.require_exact_threshold = false
-  verify.threshold = 53.3
-end
-
-task default: %i[spec rubocop verify_measurements]
+task default: %i[spec rubocop]

--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -23,58 +23,68 @@ module Delayed
 
         before_save :set_default_run_at
 
-        def self.db_time_now
-          Time.now.utc
-        end
-
-        # Reserves one job for the worker.
-        #
-        # Atomically picks and locks one job from the collection.
-        def self.reserve(worker, max_run_time = Worker.max_run_time)
-          right_now = db_time_now
-          criteria = reservation_criteria(worker, right_now, max_run_time)
-          criteria.find_one_and_update(
-            { '$set' => { locked_at: right_now, locked_by: worker.name } },
-            return_document: :after
-          )
-        end
-
-        # Mongo criteria matching all the jobs the worker can reserve.
-        #
-        # Jobs are sorted by priority and run_at.
-        #
-        # @api private
-        def self.reservation_criteria(worker, right_now, max_run_time)
-          criteria = where(
-            run_at: { '$lte' => right_now },
-            failed_at: nil
-          ).any_of(
-            { locked_by: worker.name },
-            { locked_at: nil },
-            locked_at: { '$lt' => (right_now - max_run_time) }
-          )
-
-          criteria = criteria.gte(priority: Worker.min_priority.to_i) if Worker.min_priority
-          criteria = criteria.lte(priority: Worker.max_priority.to_i) if Worker.max_priority
-          criteria = criteria.any_in(queue: Worker.queues) if Worker.queues.any?
-          criteria = criteria.desc(:locked_by).asc(:priority).asc(:run_at)
-
-          criteria
-        end
-
-        # When a worker is exiting, make sure we don't have any locked jobs.
-        def self.clear_locks!(worker_name)
-          where(locked_by: worker_name).update_all(locked_at: nil, locked_by: nil)
-        end
-
         def reload(*args)
           reset
           super
         end
 
-        # Hook method that is called after a new worker is forked
-        def self.after_fork
-          ::Mongoid.disconnect_clients
+        class << self
+          def db_time_now
+            Time.now.utc
+          end
+
+          # Reserves one job for the worker.
+          # Atomically picks and locks one job from the collection.
+          def reserve(worker, max_run_time = Worker.max_run_time)
+            right_now = db_time_now
+            criteria = reservation_criteria(worker, right_now, max_run_time)
+            criteria.find_one_and_update(
+              { '$set' => { locked_at: right_now, locked_by: worker.name } },
+              return_document: :after
+            )
+          end
+
+          # When a worker is exiting, make sure we don't have any locked jobs.
+          def clear_locks!(worker_name)
+            where(locked_by: worker_name).update_all(locked_at: nil, locked_by: nil)
+          end
+
+          # In a multi-process setup, this will be called at boot time
+          # to close unnecessary database connections on the parent process.
+          def before_fork
+            ::Mongoid.disconnect_clients
+          end
+
+          # In a multi-process setup, this will be called to ensure fresh
+          # database connections are immediately made on each newly spawned child process.
+          def after_fork
+            ::Mongoid::Clients.clients.each do |_name, client|
+              client.close
+              client.reconnect
+            end
+          end
+
+          private
+
+          # Mongo criteria matching all the jobs the worker can reserve.
+          # Jobs are sorted by priority and run_at.
+          def reservation_criteria(worker, right_now, max_run_time)
+            criteria = where(
+              run_at: { '$lte' => right_now },
+              failed_at: nil
+            ).any_of(
+              { locked_by: worker.name },
+              { locked_at: nil },
+              locked_at: { '$lt' => (right_now - max_run_time) }
+            )
+
+            criteria = criteria.gte(priority: Worker.min_priority.to_i) if Worker.min_priority
+            criteria = criteria.lte(priority: Worker.max_priority.to_i) if Worker.max_priority
+            criteria = criteria.any_in(queue: Worker.queues) if Worker.queues.any?
+            criteria = criteria.desc(:locked_by).asc(:priority).asc(:run_at)
+
+            criteria
+          end
         end
       end
     end

--- a/spec/delayed_job_mongoid_spec.rb
+++ b/spec/delayed_job_mongoid_spec.rb
@@ -11,4 +11,19 @@ describe Delayed::Backend::Mongoid::Job do
       expect(job.reload.payload_object).to be_a StoryWrapperJob
     end
   end
+
+  describe '.before_fork' do
+    it 'disconnects Mongoid' do
+      expect(::Mongoid).to receive(:disconnect_clients)
+      Delayed::Job.before_fork
+    end
+  end
+
+  describe '.after_fork' do
+    it 'reconnects Mongoid' do
+      expect_any_instance_of(::Mongo::Client).to receive(:close)
+      expect_any_instance_of(::Mongo::Client).to receive(:reconnect)
+      Delayed::Job.after_fork
+    end
+  end
 end

--- a/spec/delayed_job_mongoid_spec.rb
+++ b/spec/delayed_job_mongoid_spec.rb
@@ -20,6 +20,9 @@ describe Delayed::Backend::Mongoid::Job do
   end
 
   describe '.after_fork' do
+    # ensure Mongoid is connected
+    before { ::Delayed::Job.first }
+
     it 'reconnects Mongoid' do
       expect_any_instance_of(::Mongo::Client).to receive(:close)
       expect_any_instance_of(::Mongo::Client).to receive(:reconnect)


### PR DESCRIPTION
This is a follow-up to #81.

I've updated the `before_fork` and `after_fork` callbacks. Here's the nuts and bolts:

- `before_fork` is called by DelayedJob *only* on the parent process, which doesn't ever execute jobs. Since this doesn't need to talk to the DB, we should ensure it's Mongoid connections are closed.
- `after_fork` is called on child processes as they are forked from the parent. I've updated the logic to obtain fresh connections. Technically speaking this is not necessary as a Mongoid 5+, because the Mongo Ruby Driver [checks if pid to see if it has been forked](https://github.com/mongodb/mongo-ruby-driver/blob/238db20fcab28848ced85ca6f127c1a2f86877fd/lib/mongo/server/connectable.rb#L99). However, since we know we are forking it's good practice to do this immediately rather than waiting for Mongo Driver to do it.

In addition, this PR make some Job class method private which should not be exposed publicly.

I've added specs to increase coverage. I've also removed the YARDstick gem which verifies documentation. Bye-bye.