### PR TITLE
Add additional indexes

### DIFF
--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -20,8 +20,9 @@ module Delayed
         field :queue,       type: String
 
         index locked_by: -1, priority: 1, run_at: 1
+        index queue: 1, locked_by: -1, priority: 1, run_at: 1
         index failed_at: 1, locked_by: -1, priority: 1, run_at: 1
-        index queue: 1, failed_at: 1, locked_by: -1, priority: 1, run_at: 1
+        index failed_at: 1, queue: 1, locked_by: -1, priority: 1, run_at: 1
 
         before_save :set_default_run_at
 

--- a/lib/delayed/backend/mongoid.rb
+++ b/lib/delayed/backend/mongoid.rb
@@ -20,6 +20,8 @@ module Delayed
         field :queue,       type: String
 
         index locked_by: -1, priority: 1, run_at: 1
+        index failed_at: 1, locked_by: -1, priority: 1, run_at: 1
+        index queue: 1, failed_at: 1, locked_by: -1, priority: 1, run_at: 1
 
         before_save :set_default_run_at
 


### PR DESCRIPTION
The queries generated by the `#reservation_criteria` method are not indexed properly. I've learned this the hard way...

- `where(failed_at: nil)` is always set, so we need this at the front of our index. (If there are a large amount of failed jobs, we'll end up scanning them)
- `any_in(queue: ...)` is optional, so we need to have a second index with this at the front.

![image](https://user-images.githubusercontent.com/27655/128355800-e15b9597-2665-48c5-aeed-8b53f2d45e2f.png)
